### PR TITLE
[Refactor/#67] 만다라트 분기 추가 v.2

### DIFF
--- a/src/common/component/Mandalart/Mandalart.css.ts
+++ b/src/common/component/Mandalart/Mandalart.css.ts
@@ -11,21 +11,21 @@ export const grid = {
   TODO_SUB: style({
     ...baseGrid,
     width: 'fit-content',
-    gap: '0.8rem',
+    gap: '1rem',
   }),
   TODO_MAIN: style({
     ...baseGrid,
     width: 'fit-content',
-    gap: '1.2rem',
+    gap: '1.6rem',
   }),
   TODO_EDIT: style({
     ...baseGrid,
     width: 'fit-content',
-    gap: '1rem',
+    gap: '2rem',
   }),
   MY_MANDAL: style({
     ...baseGrid,
     width: 'fit-content',
-    gap: '1.6rem',
+    gap: '3rem',
   }),
 };

--- a/src/common/component/Mandalart/Mandalart.css.ts
+++ b/src/common/component/Mandalart/Mandalart.css.ts
@@ -1,17 +1,31 @@
 import { style } from '@vanilla-extract/css';
 
-export const gridDefault = style({
+const baseGrid = {
   display: 'grid',
   gridTemplateColumns: 'repeat(3, 1fr)',
-  gap: '1.6rem',
-  width: 'fit-content',
+  gap: '1.2rem',
   margin: '0 auto',
-});
+};
 
-export const gridSmall = style({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  gap: '2rem',
-  width: 'fit-content',
-  margin: '0 auto',
-});
+export const grid = {
+  TODO_SUB: style({
+    ...baseGrid,
+    width: 'fit-content',
+    gap: '0.8rem',
+  }),
+  TODO_MAIN: style({
+    ...baseGrid,
+    width: 'fit-content',
+    gap: '1.2rem',
+  }),
+  TODO_EDIT: style({
+    ...baseGrid,
+    width: 'fit-content',
+    gap: '1rem',
+  }),
+  MY_MANDAL: style({
+    ...baseGrid,
+    width: 'fit-content',
+    gap: '1.6rem',
+  }),
+};

--- a/src/common/component/Mandalart/Mandalart.stories.tsx
+++ b/src/common/component/Mandalart/Mandalart.stories.tsx
@@ -62,46 +62,81 @@ const CUSTOM_GOALS = {
       cycle: 'DAILY' as Cycle,
     },
   ],
-  completedGoals: [1, 3, 5],
+  completedGoals: [],
 };
 
 export const Default: Story = {
   args: {
     mainGoal: '메인 목표를 입력하세요',
     subGoals: MOCK_MANDALART_DATA.subGoals,
+    size: 'TODO_MAIN',
   },
-  render: (args) => (
-    <div style={{ display: 'flex', gap: '2rem' }}>
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
       <div>
-        <h3 style={{ color: 'white', marginBottom: '1rem' }}>Default 사이즈</h3>
-        <Mandalart {...args} />
+        <h3 style={{ color: 'white', marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
+        <Mandalart
+          mainGoal="메인 목표를 입력하세요"
+          subGoals={MOCK_MANDALART_DATA.subGoals}
+          size="TODO_SUB"
+        />
       </div>
       <div>
-        <h3 style={{ color: 'white', marginBottom: '1rem' }}>Small 사이즈</h3>
-        <Mandalart {...args} size="small" />
+        <h3 style={{ color: 'white', marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
+        <Mandalart
+          mainGoal="메인 목표를 입력하세요"
+          subGoals={MOCK_MANDALART_DATA.subGoals}
+          size="TODO_MAIN"
+        />
+      </div>
+      <div>
+        <h3 style={{ color: 'white', marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
+        <Mandalart
+          mainGoal="메인 목표를 입력하세요"
+          subGoals={MOCK_MANDALART_DATA.subGoals}
+          size="TODO_EDIT"
+        />
+      </div>
+      <div>
+        <h3 style={{ color: 'white', marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
+        <Mandalart
+          mainGoal="메인 목표를 입력하세요"
+          subGoals={MOCK_MANDALART_DATA.subGoals}
+          size="MY_MANDAL"
+        />
       </div>
     </div>
   ),
 };
 
-export const Small: Story = {
+export const TodoSub: Story = {
   args: {
-    mainGoal: '메인 목표를 입력하세요',
-    subGoals: CUSTOM_GOALS.subGoals,
-    size: 'small',
+    ...CUSTOM_GOALS,
+    size: 'TODO_SUB',
   },
   render: (args) => <Mandalart {...args} />,
 };
 
-export const WithCustomGoals: Story = {
-  args: CUSTOM_GOALS,
+export const TodoMain: Story = {
+  args: {
+    ...CUSTOM_GOALS,
+    size: 'TODO_MAIN',
+  },
   render: (args) => <Mandalart {...args} />,
 };
 
-export const WithCustomGoalsSmall: Story = {
+export const TodoEdit: Story = {
   args: {
     ...CUSTOM_GOALS,
-    size: 'small',
+    size: 'TODO_EDIT',
+  },
+  render: (args) => <Mandalart {...args} />,
+};
+
+export const MyMandal: Story = {
+  args: {
+    ...CUSTOM_GOALS,
+    size: 'MY_MANDAL',
   },
   render: (args) => <Mandalart {...args} />,
 };

--- a/src/common/component/Mandalart/Mandalart.tsx
+++ b/src/common/component/Mandalart/Mandalart.tsx
@@ -17,6 +17,7 @@ interface MandalartProps {
   mainGoal?: string;
   subGoals?: SubGoal[];
   size: MandalartSize;
+  onGoalClick?: (position: number) => void;
 }
 
 const CENTER_INDEX = 4;
@@ -25,11 +26,13 @@ const Mandalart = ({
   mainGoal = MOCK_MANDALART_DATA.mainGoal,
   subGoals = MOCK_MANDALART_DATA.subGoals,
   size,
+  onGoalClick,
 }: MandalartProps) => {
   const [selectedGoal, setSelectedGoal] = useState<number | null>(null);
 
   const handleGoalClick = (position: number) => {
     setSelectedGoal(selectedGoal === position ? null : position);
+    onGoalClick?.(position);
   };
 
   const renderSquare = (index: number) => {

--- a/src/common/component/Mandalart/Mandalart.tsx
+++ b/src/common/component/Mandalart/Mandalart.tsx
@@ -5,7 +5,7 @@ import * as styles from './Mandalart.css';
 import { MOCK_MANDALART_DATA } from './mock';
 
 export type Cycle = 'DAILY' | 'WEEKLY' | 'ONCE';
-export type MandalartSize = 'TODO_SUB' | 'TODO_MAIN' | 'TODO_EDIT' | 'MY_MANDAL';
+export type MandalartType = 'TODO_SUB' | 'TODO_MAIN' | 'TODO_EDIT' | 'MY_MANDAL';
 
 export interface SubGoal {
   title: string;
@@ -16,7 +16,7 @@ export interface SubGoal {
 interface MandalartProps {
   mainGoal?: string;
   subGoals?: SubGoal[];
-  size: MandalartSize;
+  type: MandalartType;
   onGoalClick?: (position: number) => void;
 }
 
@@ -25,7 +25,7 @@ const CENTER_INDEX = 4;
 const Mandalart = ({
   mainGoal = MOCK_MANDALART_DATA.mainGoal,
   subGoals = MOCK_MANDALART_DATA.subGoals,
-  size,
+  type,
   onGoalClick,
 }: MandalartProps) => {
   const [selectedGoal, setSelectedGoal] = useState<number | null>(null);
@@ -37,7 +37,7 @@ const Mandalart = ({
 
   const renderSquare = (index: number) => {
     if (index === CENTER_INDEX) {
-      return <Main key={index} content={mainGoal} size={size} />;
+      return <Main key={index} content={mainGoal} type={type} />;
     }
 
     const subGoalIndex = index > CENTER_INDEX ? index - 1 : index;
@@ -49,7 +49,7 @@ const Mandalart = ({
         content={subGoal.title}
         isCompleted={selectedGoal === subGoalIndex}
         onClick={() => handleGoalClick(subGoalIndex)}
-        size={size}
+        type={type}
       />
     );
   };
@@ -58,7 +58,7 @@ const Mandalart = ({
     .fill(null)
     .map((_, index) => renderSquare(index));
 
-  return <div className={styles.grid[size]}>{squares}</div>;
+  return <div className={styles.grid[type]}>{squares}</div>;
 };
 
 export default Mandalart;

--- a/src/common/component/Mandalart/Mandalart.tsx
+++ b/src/common/component/Mandalart/Mandalart.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
-import { Square } from './Square';
+import { Main, Sub } from './Square';
 import * as styles from './Mandalart.css';
 import { MOCK_MANDALART_DATA } from './mock';
 
 export type Cycle = 'DAILY' | 'WEEKLY' | 'ONCE';
-export type MandalartSize = 'small' | 'default';
+export type MandalartSize = 'TODO_SUB' | 'TODO_MAIN' | 'TODO_EDIT' | 'MY_MANDAL';
 
 export interface SubGoal {
   title: string;
@@ -16,7 +16,7 @@ export interface SubGoal {
 interface MandalartProps {
   mainGoal?: string;
   subGoals?: SubGoal[];
-  size?: MandalartSize;
+  size: MandalartSize;
 }
 
 const CENTER_INDEX = 4;
@@ -24,7 +24,7 @@ const CENTER_INDEX = 4;
 const Mandalart = ({
   mainGoal = MOCK_MANDALART_DATA.mainGoal,
   subGoals = MOCK_MANDALART_DATA.subGoals,
-  size = 'default',
+  size,
 }: MandalartProps) => {
   const [selectedGoal, setSelectedGoal] = useState<number | null>(null);
 
@@ -34,14 +34,14 @@ const Mandalart = ({
 
   const renderSquare = (index: number) => {
     if (index === CENTER_INDEX) {
-      return <Square.Main key={index} content={mainGoal} size={size} />;
+      return <Main key={index} content={mainGoal} size={size} />;
     }
 
     const subGoalIndex = index > CENTER_INDEX ? index - 1 : index;
     const subGoal = subGoals[subGoalIndex];
 
     return (
-      <Square.Sub
+      <Sub
         key={index}
         content={subGoal.title}
         isCompleted={selectedGoal === subGoalIndex}
@@ -55,7 +55,7 @@ const Mandalart = ({
     .fill(null)
     .map((_, index) => renderSquare(index));
 
-  return <div className={size === 'small' ? styles.gridSmall : styles.gridDefault}>{squares}</div>;
+  return <div className={styles.grid[size]}>{squares}</div>;
 };
 
 export default Mandalart;

--- a/src/common/component/Mandalart/Square/Square.css.ts
+++ b/src/common/component/Mandalart/Square/Square.css.ts
@@ -13,28 +13,24 @@ const SQUARE_SIZES = {
     height: '9.6rem',
     mainFont: fonts.body04,
     subFont: fonts.caption01,
-    borderWidth: '0.8rem',
   },
   TODO_MAIN: {
     width: '19.6rem',
     height: '19.6rem',
     mainFont: fonts.title03,
     subFont: fonts.subtitle01,
-    borderWidth: '0.8rem',
   },
   TODO_EDIT: {
     width: '16rem',
     height: '16rem',
     mainFont: fonts.subtitle01,
     subFont: fonts.subtitle05,
-    borderWidth: '0.8rem',
   },
   MY_MANDAL: {
     width: '29.8rem',
     height: '29.8rem',
     mainFont: fonts.display02,
     subFont: fonts.title01,
-    borderWidth: '0.8rem',
   },
 } as const;
 
@@ -81,7 +77,7 @@ export const mainCell = {
     SQUARE_SIZES.MY_MANDAL.mainFont,
     {
       color: colors.white01,
-      backgroundImage: colors.gradient04,
+      backgroundImage: colors.gradient05,
     },
   ]),
 };
@@ -93,15 +89,6 @@ export const subCell = {
     {
       color: colors.grey8,
       background: colors.grey2,
-      ':hover': {
-        background: colors.grey3,
-      },
-      selectors: {
-        '&[data-completed="true"]': {
-          border: `${SQUARE_SIZES.TODO_SUB.borderWidth} solid #305088`,
-          background: colors.grey2,
-        },
-      },
     },
   ]),
   TODO_MAIN: style([
@@ -115,7 +102,7 @@ export const subCell = {
       },
       selectors: {
         '&[data-completed="true"]': {
-          border: `${SQUARE_SIZES.TODO_MAIN.borderWidth} solid #305088`,
+          border: `0.4rem solid #305088`,
           background: colors.grey2,
         },
       },
@@ -132,7 +119,7 @@ export const subCell = {
       },
       selectors: {
         '&[data-completed="true"]': {
-          border: `${SQUARE_SIZES.TODO_EDIT.borderWidth} solid #305088`,
+          border: `0.3rem solid #305088`,
           background: colors.grey2,
         },
       },
@@ -142,17 +129,8 @@ export const subCell = {
     createBaseCell('MY_MANDAL'),
     SQUARE_SIZES.MY_MANDAL.subFont,
     {
-      color: colors.grey8,
-      background: colors.grey2,
-      ':hover': {
-        background: colors.grey3,
-      },
-      selectors: {
-        '&[data-completed="true"]': {
-          border: `${SQUARE_SIZES.MY_MANDAL.borderWidth} solid #305088`,
-          background: colors.grey2,
-        },
-      },
+      color: colors.white01,
+      backgroundImage: colors.gradient04,
     },
   ]),
 };

--- a/src/common/component/Mandalart/Square/Square.css.ts
+++ b/src/common/component/Mandalart/Square/Square.css.ts
@@ -7,7 +7,7 @@ export const squareContainer = style({
   margin: '0 auto',
 });
 
-const SQUARE_SIZES = {
+const SQUARE_TYPES = {
   TODO_SUB: {
     width: '9.6rem',
     height: '9.6rem',
@@ -34,7 +34,7 @@ const SQUARE_SIZES = {
   },
 } as const;
 
-const createBaseCell = (size: keyof typeof SQUARE_SIZES) =>
+const createBaseCell = (type: keyof typeof SQUARE_TYPES) =>
   style({
     borderRadius: '8px',
     cursor: 'pointer',
@@ -42,15 +42,15 @@ const createBaseCell = (size: keyof typeof SQUARE_SIZES) =>
     alignItems: 'center',
     justifyContent: 'center',
     textAlign: 'center',
-    width: SQUARE_SIZES[size].width,
-    height: SQUARE_SIZES[size].height,
+    width: SQUARE_TYPES[type].width,
+    height: SQUARE_TYPES[type].height,
     boxSizing: 'border-box',
   });
 
 export const mainCell = {
   TODO_SUB: style([
     createBaseCell('TODO_SUB'),
-    SQUARE_SIZES.TODO_SUB.mainFont,
+    SQUARE_TYPES.TODO_SUB.mainFont,
     {
       color: colors.white01,
       backgroundImage: colors.gradient04,
@@ -58,7 +58,7 @@ export const mainCell = {
   ]),
   TODO_MAIN: style([
     createBaseCell('TODO_MAIN'),
-    SQUARE_SIZES.TODO_MAIN.mainFont,
+    SQUARE_TYPES.TODO_MAIN.mainFont,
     {
       color: colors.white01,
       backgroundImage: colors.gradient04,
@@ -66,7 +66,7 @@ export const mainCell = {
   ]),
   TODO_EDIT: style([
     createBaseCell('TODO_EDIT'),
-    SQUARE_SIZES.TODO_EDIT.mainFont,
+    SQUARE_TYPES.TODO_EDIT.mainFont,
     {
       color: colors.white01,
       backgroundImage: colors.gradient04,
@@ -74,7 +74,7 @@ export const mainCell = {
   ]),
   MY_MANDAL: style([
     createBaseCell('MY_MANDAL'),
-    SQUARE_SIZES.MY_MANDAL.mainFont,
+    SQUARE_TYPES.MY_MANDAL.mainFont,
     {
       color: colors.white01,
       backgroundImage: colors.gradient05,
@@ -85,7 +85,7 @@ export const mainCell = {
 export const subCell = {
   TODO_SUB: style([
     createBaseCell('TODO_SUB'),
-    SQUARE_SIZES.TODO_SUB.subFont,
+    SQUARE_TYPES.TODO_SUB.subFont,
     {
       color: colors.grey8,
       background: colors.grey2,
@@ -93,7 +93,7 @@ export const subCell = {
   ]),
   TODO_MAIN: style([
     createBaseCell('TODO_MAIN'),
-    SQUARE_SIZES.TODO_MAIN.subFont,
+    SQUARE_TYPES.TODO_MAIN.subFont,
     {
       color: colors.grey8,
       background: colors.grey2,
@@ -102,7 +102,7 @@ export const subCell = {
       },
       selectors: {
         '&[data-completed="true"]': {
-          border: `0.4rem solid #305088`,
+          border: '0.4rem solid #305088',
           background: colors.grey2,
         },
       },
@@ -110,7 +110,7 @@ export const subCell = {
   ]),
   TODO_EDIT: style([
     createBaseCell('TODO_EDIT'),
-    SQUARE_SIZES.TODO_EDIT.subFont,
+    SQUARE_TYPES.TODO_EDIT.subFont,
     {
       color: colors.grey8,
       background: colors.grey2,
@@ -119,7 +119,7 @@ export const subCell = {
       },
       selectors: {
         '&[data-completed="true"]': {
-          border: `0.3rem solid #305088`,
+          border: '0.3rem solid #305088',
           background: colors.grey2,
         },
       },
@@ -127,7 +127,7 @@ export const subCell = {
   ]),
   MY_MANDAL: style([
     createBaseCell('MY_MANDAL'),
-    SQUARE_SIZES.MY_MANDAL.subFont,
+    SQUARE_TYPES.MY_MANDAL.subFont,
     {
       color: colors.white01,
       backgroundImage: colors.gradient04,

--- a/src/common/component/Mandalart/Square/Square.css.ts
+++ b/src/common/component/Mandalart/Square/Square.css.ts
@@ -7,81 +7,152 @@ export const squareContainer = style({
   margin: '0 auto',
 });
 
-const baseCellDefault = style({
-  borderRadius: '8px',
-  cursor: 'pointer',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  textAlign: 'center',
-  width: '19.6rem',
-  height: '19.6rem',
-  boxSizing: 'border-box',
-});
-
-const baseCellSmall = style({
-  borderRadius: '8px',
-  cursor: 'pointer',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  textAlign: 'center',
-  width: '16rem',
-  height: '16rem',
-  boxSizing: 'border-box',
-});
-
-export const mainCellDefault = style([
-  baseCellDefault,
-  fonts.title03,
-  {
-    color: colors.white01,
-    backgroundImage: colors.gradient04,
+const SQUARE_SIZES = {
+  TODO_SUB: {
+    width: '9.6rem',
+    height: '9.6rem',
+    mainFont: fonts.body04,
+    subFont: fonts.caption01,
+    borderWidth: '0.8rem',
   },
-]);
-
-export const mainCellSmall = style([
-  baseCellSmall,
-  fonts.subtitle01,
-  {
-    color: colors.white01,
-    backgroundImage: colors.gradient04,
-    padding: '1.4rem',
+  TODO_MAIN: {
+    width: '19.6rem',
+    height: '19.6rem',
+    mainFont: fonts.title03,
+    subFont: fonts.subtitle01,
+    borderWidth: '0.8rem',
   },
-]);
+  TODO_EDIT: {
+    width: '16rem',
+    height: '16rem',
+    mainFont: fonts.subtitle01,
+    subFont: fonts.subtitle05,
+    borderWidth: '0.8rem',
+  },
+  MY_MANDAL: {
+    width: '29.8rem',
+    height: '29.8rem',
+    mainFont: fonts.display02,
+    subFont: fonts.title01,
+    borderWidth: '0.8rem',
+  },
+} as const;
 
-export const subCellDefault = style([
-  baseCellDefault,
-  fonts.subtitle01,
-  {
-    color: colors.grey8,
-    background: colors.grey2,
-    ':hover': {
-      background: colors.grey3,
+const createBaseCell = (size: keyof typeof SQUARE_SIZES) =>
+  style({
+    borderRadius: '8px',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    width: SQUARE_SIZES[size].width,
+    height: SQUARE_SIZES[size].height,
+    boxSizing: 'border-box',
+  });
+
+export const mainCell = {
+  TODO_SUB: style([
+    createBaseCell('TODO_SUB'),
+    SQUARE_SIZES.TODO_SUB.mainFont,
+    {
+      color: colors.white01,
+      backgroundImage: colors.gradient04,
     },
-    selectors: {
-      '&[data-completed="true"]': {
-        border: '0.4rem solid #305088',
-        background: colors.grey2,
+  ]),
+  TODO_MAIN: style([
+    createBaseCell('TODO_MAIN'),
+    SQUARE_SIZES.TODO_MAIN.mainFont,
+    {
+      color: colors.white01,
+      backgroundImage: colors.gradient04,
+    },
+  ]),
+  TODO_EDIT: style([
+    createBaseCell('TODO_EDIT'),
+    SQUARE_SIZES.TODO_EDIT.mainFont,
+    {
+      color: colors.white01,
+      backgroundImage: colors.gradient04,
+    },
+  ]),
+  MY_MANDAL: style([
+    createBaseCell('MY_MANDAL'),
+    SQUARE_SIZES.MY_MANDAL.mainFont,
+    {
+      color: colors.white01,
+      backgroundImage: colors.gradient04,
+    },
+  ]),
+};
+
+export const subCell = {
+  TODO_SUB: style([
+    createBaseCell('TODO_SUB'),
+    SQUARE_SIZES.TODO_SUB.subFont,
+    {
+      color: colors.grey8,
+      background: colors.grey2,
+      ':hover': {
+        background: colors.grey3,
+      },
+      selectors: {
+        '&[data-completed="true"]': {
+          border: `${SQUARE_SIZES.TODO_SUB.borderWidth} solid #305088`,
+          background: colors.grey2,
+        },
       },
     },
-  },
-]);
-
-export const subCellSmall = style([
-  baseCellSmall,
-  fonts.subtitle05,
-  {
-    color: colors.grey8,
-    background: colors.grey2,
-    ':hover': {
-      background: colors.grey3,
-    },
-    selectors: {
-      '&[data-completed="true"]': {
-        border: '0.3rem solid #305088',
-        background: colors.grey2,
+  ]),
+  TODO_MAIN: style([
+    createBaseCell('TODO_MAIN'),
+    SQUARE_SIZES.TODO_MAIN.subFont,
+    {
+      color: colors.grey8,
+      background: colors.grey2,
+      ':hover': {
+        background: colors.grey3,
+      },
+      selectors: {
+        '&[data-completed="true"]': {
+          border: `${SQUARE_SIZES.TODO_MAIN.borderWidth} solid #305088`,
+          background: colors.grey2,
+        },
       },
     },
-  },
-]);
+  ]),
+  TODO_EDIT: style([
+    createBaseCell('TODO_EDIT'),
+    SQUARE_SIZES.TODO_EDIT.subFont,
+    {
+      color: colors.grey8,
+      background: colors.grey2,
+      ':hover': {
+        background: colors.grey3,
+      },
+      selectors: {
+        '&[data-completed="true"]': {
+          border: `${SQUARE_SIZES.TODO_EDIT.borderWidth} solid #305088`,
+          background: colors.grey2,
+        },
+      },
+    },
+  ]),
+  MY_MANDAL: style([
+    createBaseCell('MY_MANDAL'),
+    SQUARE_SIZES.MY_MANDAL.subFont,
+    {
+      color: colors.grey8,
+      background: colors.grey2,
+      ':hover': {
+        background: colors.grey3,
+      },
+      selectors: {
+        '&[data-completed="true"]': {
+          border: `${SQUARE_SIZES.MY_MANDAL.borderWidth} solid #305088`,
+          background: colors.grey2,
+        },
+      },
+    },
+  ]),
+};

--- a/src/common/component/Mandalart/Square/Square.stories.tsx
+++ b/src/common/component/Mandalart/Square/Square.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Main, Sub } from '.';
-import type { MandalartSize } from '../Mandalart';
+import type { MandalartType } from '../Mandalart';
 
 import { colors } from '@/style/token';
 
@@ -16,7 +16,7 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {
-    size: {
+    type: {
       control: 'select',
       options: ['TODO_SUB', 'TODO_MAIN', 'TODO_EDIT', 'MY_MANDAL'],
     },
@@ -28,13 +28,13 @@ type Story = StoryObj<typeof meta>;
 
 const handleClick = () => {};
 
-const SizePreview = ({ title, size }: { title: string; size: MandalartSize }) => (
+const TypePreview = ({ title, type }: { title: string; type: MandalartType }) => (
   <div>
     <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>{title}</h3>
     <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
-      <Main content="상위 목표" size={size} />
-      <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size={size} />
-      <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size={size} />
+      <Main content="상위 목표" type={type} />
+      <Sub content="세부 목표" isCompleted={false} onClick={handleClick} type={type} />
+      <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} type={type} />
     </div>
   </div>
 );
@@ -42,14 +42,14 @@ const SizePreview = ({ title, size }: { title: string; size: MandalartSize }) =>
 export const Default: Story = {
   args: {
     content: '상위 목표',
-    size: 'TODO_MAIN',
+    type: 'TODO_MAIN',
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
-      <SizePreview title="TODO_SUB (96px)" size="TODO_SUB" />
-      <SizePreview title="TODO_MAIN (196px)" size="TODO_MAIN" />
-      <SizePreview title="TODO_EDIT (160px)" size="TODO_EDIT" />
-      <SizePreview title="MY_MANDAL (298px)" size="MY_MANDAL" />
+      <TypePreview title="TODO_SUB (96px)" type="TODO_SUB" />
+      <TypePreview title="TODO_MAIN (196px)" type="TODO_MAIN" />
+      <TypePreview title="TODO_EDIT (160px)" type="TODO_EDIT" />
+      <TypePreview title="MY_MANDAL (298px)" type="MY_MANDAL" />
     </div>
   ),
 };
@@ -57,25 +57,25 @@ export const Default: Story = {
 export const MainGoal: Story = {
   args: {
     content: '메인 목표를 입력하세요',
-    size: 'TODO_MAIN',
+    type: 'TODO_MAIN',
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
-        <Main content="메인 목표를 입력하세요" size="TODO_SUB" />
+        <Main content="메인 목표를 입력하세요" type="TODO_SUB" />
       </div>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
-        <Main content="메인 목표를 입력하세요" size="TODO_MAIN" />
+        <Main content="메인 목표를 입력하세요" type="TODO_MAIN" />
       </div>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
-        <Main content="메인 목표를 입력하세요" size="TODO_EDIT" />
+        <Main content="메인 목표를 입력하세요" type="TODO_EDIT" />
       </div>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
-        <Main content="메인 목표를 입력하세요" size="MY_MANDAL" />
+        <Main content="메인 목표를 입력하세요" type="MY_MANDAL" />
       </div>
     </div>
   ),
@@ -84,7 +84,7 @@ export const MainGoal: Story = {
 export const SubGoalStates: Story = {
   args: {
     content: '세부 목표를 입력하세요',
-    size: 'TODO_MAIN',
+    type: 'TODO_MAIN',
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
@@ -95,13 +95,13 @@ export const SubGoalStates: Story = {
             content="세부 목표를 입력하세요"
             isCompleted={false}
             onClick={handleClick}
-            size="TODO_SUB"
+            type="TODO_SUB"
           />
           <Sub
             content="완료된 목표입니다"
             isCompleted={true}
             onClick={handleClick}
-            size="TODO_SUB"
+            type="TODO_SUB"
           />
         </div>
       </div>
@@ -112,13 +112,13 @@ export const SubGoalStates: Story = {
             content="세부 목표를 입력하세요"
             isCompleted={false}
             onClick={handleClick}
-            size="TODO_MAIN"
+            type="TODO_MAIN"
           />
           <Sub
             content="완료된 목표입니다"
             isCompleted={true}
             onClick={handleClick}
-            size="TODO_MAIN"
+            type="TODO_MAIN"
           />
         </div>
       </div>
@@ -129,13 +129,13 @@ export const SubGoalStates: Story = {
             content="세부 목표를 입력하세요"
             isCompleted={false}
             onClick={handleClick}
-            size="TODO_EDIT"
+            type="TODO_EDIT"
           />
           <Sub
             content="완료된 목표입니다"
             isCompleted={true}
             onClick={handleClick}
-            size="TODO_EDIT"
+            type="TODO_EDIT"
           />
         </div>
       </div>
@@ -146,13 +146,13 @@ export const SubGoalStates: Story = {
             content="세부 목표를 입력하세요"
             isCompleted={false}
             onClick={handleClick}
-            size="MY_MANDAL"
+            type="MY_MANDAL"
           />
           <Sub
             content="완료된 목표입니다"
             isCompleted={true}
             onClick={handleClick}
-            size="MY_MANDAL"
+            type="MY_MANDAL"
           />
         </div>
       </div>

--- a/src/common/component/Mandalart/Square/Square.stories.tsx
+++ b/src/common/component/Mandalart/Square/Square.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { Main, Sub } from '.';
+import type { MandalartSize } from '../Mandalart';
 
 import { colors } from '@/style/token';
 
@@ -14,6 +15,12 @@ const meta = {
     },
   },
   tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['TODO_SUB', 'TODO_MAIN', 'TODO_EDIT', 'MY_MANDAL'],
+    },
+  },
 } satisfies Meta<typeof Main>;
 
 export default meta;
@@ -21,44 +28,28 @@ type Story = StoryObj<typeof meta>;
 
 const handleClick = () => {};
 
+const SizePreview = ({ title, size }: { title: string; size: MandalartSize }) => (
+  <div>
+    <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>{title}</h3>
+    <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+      <Main content="상위 목표" size={size} />
+      <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size={size} />
+      <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size={size} />
+    </div>
+  </div>
+);
+
 export const Default: Story = {
   args: {
     content: '상위 목표',
+    size: 'TODO_MAIN',
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
-      <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
-          <Main content="상위 목표" size="TODO_SUB" />
-          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="TODO_SUB" />
-          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="TODO_SUB" />
-        </div>
-      </div>
-      <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
-          <Main content="상위 목표" size="TODO_MAIN" />
-          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="TODO_MAIN" />
-          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="TODO_MAIN" />
-        </div>
-      </div>
-      <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
-          <Main content="상위 목표" size="TODO_EDIT" />
-          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="TODO_EDIT" />
-          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="TODO_EDIT" />
-        </div>
-      </div>
-      <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
-          <Main content="상위 목표" size="MY_MANDAL" />
-          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="MY_MANDAL" />
-          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="MY_MANDAL" />
-        </div>
-      </div>
+      <SizePreview title="TODO_SUB (96px)" size="TODO_SUB" />
+      <SizePreview title="TODO_MAIN (196px)" size="TODO_MAIN" />
+      <SizePreview title="TODO_EDIT (160px)" size="TODO_EDIT" />
+      <SizePreview title="MY_MANDAL (298px)" size="MY_MANDAL" />
     </div>
   ),
 };
@@ -66,6 +57,7 @@ export const Default: Story = {
 export const MainGoal: Story = {
   args: {
     content: '메인 목표를 입력하세요',
+    size: 'TODO_MAIN',
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
@@ -92,12 +84,13 @@ export const MainGoal: Story = {
 export const SubGoalStates: Story = {
   args: {
     content: '세부 목표를 입력하세요',
+    size: 'TODO_MAIN',
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
+        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
           <Sub
             content="세부 목표를 입력하세요"
             isCompleted={false}
@@ -114,7 +107,7 @@ export const SubGoalStates: Story = {
       </div>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
+        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
           <Sub
             content="세부 목표를 입력하세요"
             isCompleted={false}
@@ -131,7 +124,7 @@ export const SubGoalStates: Story = {
       </div>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
+        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
           <Sub
             content="세부 목표를 입력하세요"
             isCompleted={false}
@@ -148,7 +141,7 @@ export const SubGoalStates: Story = {
       </div>
       <div>
         <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
-        <div style={{ display: 'flex', gap: '2rem' }}>
+        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
           <Sub
             content="세부 목표를 입력하세요"
             isCompleted={false}

--- a/src/common/component/Mandalart/Square/Square.stories.tsx
+++ b/src/common/component/Mandalart/Square/Square.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Square } from '.';
+import { Main, Sub } from '.';
 
 import { colors } from '@/style/token';
 
 const meta = {
   title: 'Components/Square',
-  component: Square.Main,
+  component: Main,
   parameters: {
     layout: 'centered',
     backgrounds: {
@@ -14,7 +14,7 @@ const meta = {
     },
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof Square.Main>;
+} satisfies Meta<typeof Main>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -25,26 +25,38 @@ export const Default: Story = {
   args: {
     content: '상위 목표',
   },
-  render: (args) => (
-    <div style={{ display: 'flex', gap: '2rem' }}>
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
       <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>Default 사이즈</h3>
-        <p style={{ color: colors.white01, marginBottom: '1rem' }}>
-          메인: title03 / 서브: subtitle01
-        </p>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
         <div style={{ display: 'flex', gap: '2rem' }}>
-          <Square.Main {...args} />
-          <Square.Sub content="세부 목표" isCompleted={false} onClick={handleClick} />
+          <Main content="상위 목표" size="TODO_SUB" />
+          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="TODO_SUB" />
+          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="TODO_SUB" />
         </div>
       </div>
       <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>Small 사이즈</h3>
-        <p style={{ color: colors.white01, marginBottom: '1rem' }}>
-          메인: body04 / 서브: subtitle05
-        </p>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
         <div style={{ display: 'flex', gap: '2rem' }}>
-          <Square.Main content="상위 목표" size="small" />
-          <Square.Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="small" />
+          <Main content="상위 목표" size="TODO_MAIN" />
+          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="TODO_MAIN" />
+          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="TODO_MAIN" />
+        </div>
+      </div>
+      <div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <Main content="상위 목표" size="TODO_EDIT" />
+          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="TODO_EDIT" />
+          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="TODO_EDIT" />
+        </div>
+      </div>
+      <div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <Main content="상위 목표" size="MY_MANDAL" />
+          <Sub content="세부 목표" isCompleted={false} onClick={handleClick} size="MY_MANDAL" />
+          <Sub content="완료된 목표" isCompleted={true} onClick={handleClick} size="MY_MANDAL" />
         </div>
       </div>
     </div>
@@ -55,15 +67,23 @@ export const MainGoal: Story = {
   args: {
     content: '메인 목표를 입력하세요',
   },
-  render: (args) => (
-    <div style={{ display: 'flex', gap: '2rem' }}>
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
       <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>Default 사이즈 (title03)</h3>
-        <Square.Main {...args} />
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
+        <Main content="메인 목표를 입력하세요" size="TODO_SUB" />
       </div>
       <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>Small 사이즈 (body04)</h3>
-        <Square.Main content="메인 목표를 입력하세요" size="small" />
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
+        <Main content="메인 목표를 입력하세요" size="TODO_MAIN" />
+      </div>
+      <div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
+        <Main content="메인 목표를 입력하세요" size="TODO_EDIT" />
+      </div>
+      <div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
+        <Main content="메인 목표를 입력하세요" size="MY_MANDAL" />
       </div>
     </div>
   ),
@@ -73,42 +93,74 @@ export const SubGoalStates: Story = {
   args: {
     content: '세부 목표를 입력하세요',
   },
-  render: (args) => (
-    <div style={{ display: 'flex', gap: '2rem' }}>
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4rem' }}>
       <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>Default 사이즈 (subtitle01)</h3>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-          <div>
-            <h4 style={{ color: colors.white01, marginBottom: '1rem' }}>기본 상태</h4>
-            <Square.Sub content={args.content} isCompleted={false} onClick={handleClick} />
-          </div>
-          <div>
-            <h4 style={{ color: colors.white01, marginBottom: '1rem' }}>완료 상태</h4>
-            <Square.Sub content="완료된 목표입니다" isCompleted={true} onClick={handleClick} />
-          </div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_SUB (96px)</h3>
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <Sub
+            content="세부 목표를 입력하세요"
+            isCompleted={false}
+            onClick={handleClick}
+            size="TODO_SUB"
+          />
+          <Sub
+            content="완료된 목표입니다"
+            isCompleted={true}
+            onClick={handleClick}
+            size="TODO_SUB"
+          />
         </div>
       </div>
       <div>
-        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>Small 사이즈 (subtitle05)</h3>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-          <div>
-            <h4 style={{ color: colors.white01, marginBottom: '1rem' }}>기본 상태</h4>
-            <Square.Sub
-              content={args.content}
-              isCompleted={false}
-              onClick={handleClick}
-              size="small"
-            />
-          </div>
-          <div>
-            <h4 style={{ color: colors.white01, marginBottom: '1rem' }}>완료 상태</h4>
-            <Square.Sub
-              content="완료된 목표입니다"
-              isCompleted={true}
-              onClick={handleClick}
-              size="small"
-            />
-          </div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_MAIN (196px)</h3>
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <Sub
+            content="세부 목표를 입력하세요"
+            isCompleted={false}
+            onClick={handleClick}
+            size="TODO_MAIN"
+          />
+          <Sub
+            content="완료된 목표입니다"
+            isCompleted={true}
+            onClick={handleClick}
+            size="TODO_MAIN"
+          />
+        </div>
+      </div>
+      <div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>TODO_EDIT (160px)</h3>
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <Sub
+            content="세부 목표를 입력하세요"
+            isCompleted={false}
+            onClick={handleClick}
+            size="TODO_EDIT"
+          />
+          <Sub
+            content="완료된 목표입니다"
+            isCompleted={true}
+            onClick={handleClick}
+            size="TODO_EDIT"
+          />
+        </div>
+      </div>
+      <div>
+        <h3 style={{ color: colors.white01, marginBottom: '1rem' }}>MY_MANDAL (298px)</h3>
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <Sub
+            content="세부 목표를 입력하세요"
+            isCompleted={false}
+            onClick={handleClick}
+            size="MY_MANDAL"
+          />
+          <Sub
+            content="완료된 목표입니다"
+            isCompleted={true}
+            onClick={handleClick}
+            size="MY_MANDAL"
+          />
         </div>
       </div>
     </div>

--- a/src/common/component/Mandalart/Square/Square.tsx
+++ b/src/common/component/Mandalart/Square/Square.tsx
@@ -1,5 +1,5 @@
 import * as styles from './Square.css';
-import type { MandalartSize } from '../Mandalart';
+import type { MandalartType } from '../Mandalart';
 
 export interface SquareProps {
   children: React.ReactNode;
@@ -7,7 +7,7 @@ export interface SquareProps {
 
 export interface CellProps {
   content: string;
-  size: MandalartSize;
+  type: MandalartType;
 }
 
 export interface SubCellProps extends CellProps {
@@ -19,18 +19,18 @@ export const Root = ({ children }: SquareProps) => {
   return <div className={styles.squareContainer}>{children}</div>;
 };
 
-export const Main = ({ content, size }: CellProps) => {
+export const Main = ({ content, type }: CellProps) => {
   return (
     <div className={styles.squareContainer}>
-      <div className={styles.mainCell[size]}>{content}</div>
+      <div className={styles.mainCell[type]}>{content}</div>
     </div>
   );
 };
 
-export const Sub = ({ content, isCompleted, onClick, size }: SubCellProps) => {
+export const Sub = ({ content, isCompleted, onClick, type }: SubCellProps) => {
   return (
     <div className={styles.squareContainer}>
-      <div className={styles.subCell[size]} data-completed={isCompleted} onClick={onClick}>
+      <div className={styles.subCell[type]} data-completed={isCompleted} onClick={onClick}>
         {content}
       </div>
     </div>

--- a/src/common/component/Mandalart/Square/Square.tsx
+++ b/src/common/component/Mandalart/Square/Square.tsx
@@ -7,7 +7,7 @@ export interface SquareProps {
 
 export interface CellProps {
   content: string;
-  size?: MandalartSize;
+  size: MandalartSize;
 }
 
 export interface SubCellProps extends CellProps {
@@ -19,24 +19,18 @@ export const Root = ({ children }: SquareProps) => {
   return <div className={styles.squareContainer}>{children}</div>;
 };
 
-export const Main = ({ content, size = 'default' }: CellProps) => {
+export const Main = ({ content, size }: CellProps) => {
   return (
     <div className={styles.squareContainer}>
-      <div className={size === 'small' ? styles.mainCellSmall : styles.mainCellDefault}>
-        {content}
-      </div>
+      <div className={styles.mainCell[size]}>{content}</div>
     </div>
   );
 };
 
-export const Sub = ({ content, isCompleted, onClick, size = 'default' }: SubCellProps) => {
+export const Sub = ({ content, isCompleted, onClick, size }: SubCellProps) => {
   return (
     <div className={styles.squareContainer}>
-      <div
-        className={size === 'small' ? styles.subCellSmall : styles.subCellDefault}
-        data-completed={isCompleted}
-        onClick={onClick}
-      >
+      <div className={styles.subCell[size]} data-completed={isCompleted} onClick={onClick}>
         {content}
       </div>
     </div>

--- a/src/common/component/Mandalart/Square/index.ts
+++ b/src/common/component/Mandalart/Square/index.ts
@@ -1,9 +1,4 @@
 import { Root, Main, Sub } from './Square';
 
-export const Square = {
-  Root,
-  Main,
-  Sub,
-} as const;
-
-export type { SquareProps, CellProps } from './Square';
+export { Root, Main, Sub };
+export type { SquareProps, CellProps, SubCellProps } from './Square';

--- a/src/common/component/Mandalart/mock.ts
+++ b/src/common/component/Mandalart/mock.ts
@@ -1,48 +1,52 @@
-import type { SubGoal } from './Mandalart';
+import type { Cycle, SubGoal } from './Mandalart';
 
-export const MOCK_MANDALART_DATA = {
-  mainGoal: '나인도트 1등하기',
+interface MockMandalartData {
+  mainGoal: string;
+  subGoals: SubGoal[];
+}
+
+export const MOCK_MANDALART_DATA: MockMandalartData = {
+  mainGoal: '메인 목표를 입력하세요',
   subGoals: [
     {
-      title: '이현준 갈구기',
+      title: '세부 목표를 입력하세요',
       position: 0,
-      cycle: 'DAILY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '매일 운동하기',
+      title: '세부 목표를 입력하세요',
       position: 1,
-      cycle: 'DAILY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '일찍 일어나기',
+      title: '세부 목표를 입력하세요',
       position: 2,
-      cycle: 'DAILY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '계획 세우기',
+      title: '세부 목표를 입력하세요',
       position: 3,
-      cycle: 'WEEKLY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '시간 관리하기',
+      title: '세부 목표를 입력하세요',
       position: 4,
-      cycle: 'WEEKLY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '건강 관리하기',
+      title: '세부 목표를 입력하세요',
       position: 5,
-      cycle: 'DAILY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '긍정적으로 생각하기',
+      title: '세부 목표를 입력하세요',
       position: 6,
-      cycle: 'DAILY',
+      cycle: 'DAILY' as Cycle,
     },
     {
-      title: '꾸준히 노력하기',
+      title: '세부 목표를 입력하세요',
       position: 7,
-      cycle: 'DAILY',
+      cycle: 'DAILY' as Cycle,
     },
-  ] as SubGoal[],
-  completedGoals: [],
+  ],
 };

--- a/src/page/todo/UpperGoal.tsx
+++ b/src/page/todo/UpperGoal.tsx
@@ -1,7 +1,13 @@
+import Mandalart from '@/common/component/Mandalart/Mandalart';
+
 const UpperGoal = () => {
   return (
     <div>
       <h2>상위 목표 설정</h2>
+      <Mandalart size={'TODO_SUB'} />
+      <Mandalart size={'TODO_MAIN'} />
+      <Mandalart size={'TODO_EDIT'} />
+      <Mandalart size={'MY_MANDAL'} />
       {/* TODO: 상위 목표 입력 폼 */}
     </div>
   );

--- a/src/page/todo/UpperGoal.tsx
+++ b/src/page/todo/UpperGoal.tsx
@@ -1,16 +1,7 @@
-import Mandalart from '@/common/component/Mandalart/Mandalart';
-import * as styles from './Todo.css';
-
 const UpperGoal = () => {
   return (
     <div>
       <h2>상위 목표 설정</h2>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-        <Mandalart type="TODO_SUB" />
-        <Mandalart type="TODO_MAIN" />
-        <Mandalart type="TODO_EDIT" />
-        <Mandalart type="MY_MANDAL" />
-      </div>
       {/* TODO: 상위 목표 입력 폼 */}
     </div>
   );

--- a/src/page/todo/UpperGoal.tsx
+++ b/src/page/todo/UpperGoal.tsx
@@ -1,13 +1,16 @@
 import Mandalart from '@/common/component/Mandalart/Mandalart';
+import * as styles from './Todo.css';
 
 const UpperGoal = () => {
   return (
     <div>
       <h2>상위 목표 설정</h2>
-      <Mandalart size={'TODO_SUB'} />
-      <Mandalart size={'TODO_MAIN'} />
-      <Mandalart size={'TODO_EDIT'} />
-      <Mandalart size={'MY_MANDAL'} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+        <Mandalart type="TODO_SUB" />
+        <Mandalart type="TODO_MAIN" />
+        <Mandalart type="TODO_EDIT" />
+        <Mandalart type="MY_MANDAL" />
+      </div>
       {/* TODO: 상위 목표 입력 폼 */}
     </div>
   );

--- a/src/shared/component/Layout/Layout.css.ts
+++ b/src/shared/component/Layout/Layout.css.ts
@@ -4,10 +4,10 @@ export const layoutContainer = style({
   display: 'flex',
   flexDirection: 'column',
   height: '100vh',
-  overflow: 'hidden',
+  overflow: 'auto',
 });
 
 export const layoutMain = style({
   flex: 1,
-  overflow: 'hidden',
+  overflow: 'auto',
 });

--- a/src/style/token/typography.css.ts
+++ b/src/style/token/typography.css.ts
@@ -9,6 +9,11 @@ export const fonts = {
     fontWeight: '700',
     lineHeight: '140%',
   },
+  display03: {
+    fontSize: '3.2rem',
+    fontWeight: '600',
+    lineHeight: '140%',
+  },
   title01: {
     fontSize: '2.8rem',
     fontWeight: '600',
@@ -27,6 +32,11 @@ export const fonts = {
   title04: {
     fontSize: '2.4rem',
     fontWeight: '600',
+    lineHeight: '140%',
+  },
+  title05: {
+    fontSize: '2.4rem',
+    fontWeight: '400',
     lineHeight: '140%',
   },
   subtitle01: {


### PR DESCRIPTION
<!-- PR 제목은 [구현 기능 종류]: 작업명으로 해주세요.-->

## 💡 Summary

<!-- 관련 있는 Issue를 태그해주세요. -->

> close #67 

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해 주세요. -->

## ✅ Tasks

<!-- 해당 PR에서 진행한 작업을 작성해 주세요. -->

- 만다라트 크기 별 분기 추가했습니다.

- 96px -> TODO_SUB
- 196px -> TODO_MAIN
- 160px -> TODO_EDIT
- 298px -> MY_MANDAL

뷰에 쓰이는 쓰임대로 네이밍 했는데, 혹시 더 좋은 의견 있으시면 주시면 감사하겠습니다!

border(테두리)는 지구가 말한 대로 토큰 사용하려고 했는데, 토큰 자체가 gradient라 background-image로만 넣을 수 있다고 해서 일단 헥스값으로 넣었습니다.
좋은 방법 알려주세요!

<!-- 기재 내용 없을 경우 해당 섹션을 삭제해 주세요. -->

## 👀 To Reviewer

<!-- 더 전달할 내용 혹은 리뷰어에게 요청하는 내용을 작성해주세요. -->

```
<Mandalart type="TODO_SUB" />
<Mandalart type="TODO_MAIN" />
<Mandalart type="TODO_EDIT" />
<Mandalart type="MY_MANDAL" />
```

이렇게 사용합니다.

<!-- 기재 내용 없을 경우 해당 섹션을 삭제해 주세요. -->

## 📸 Screenshot

<!-- 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요한 경우 .gif 형식으로 첨부해 주세요.-->

스토리북으로 확인 가능합니다.
