### PR TITLE
[FIX] 빌드 시 스토리북 테스트 비활성화

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,8 @@ import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 const dirname =
   typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
+const isTest = process.env.NODE_ENV === 'test';
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   plugins: [
@@ -35,32 +37,32 @@ export default defineConfig({
       '@type': path.resolve(__dirname, './src/type'),
     },
   },
-  test: {
-    projects: [
-      {
-        extends: true,
-        plugins: [
-          // The plugin will run tests for the stories defined in your Storybook config
-          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-          storybookTest({
-            configDir: path.join(dirname, '.storybook'),
-          }),
-        ],
-        test: {
-          name: 'storybook',
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: 'playwright',
-            instances: [
-              {
-                browser: 'chromium',
-              },
+  test: isTest
+    ? {
+        projects: [
+          {
+            extends: true,
+            plugins: [
+              storybookTest({
+                configDir: path.join(dirname, '.storybook'),
+              }),
             ],
+            test: {
+              name: 'storybook',
+              browser: {
+                enabled: true,
+                headless: true,
+                provider: 'playwright',
+                instances: [
+                  {
+                    browser: 'chromium',
+                  },
+                ],
+              },
+              setupFiles: ['.storybook/vitest.setup.ts'],
+            },
           },
-          setupFiles: ['.storybook/vitest.setup.ts'],
-        },
-      },
-    ],
-  },
+        ],
+      }
+    : undefined,
 });


### PR DESCRIPTION
<!-- PR 제목은 [구현 기능 종류]: 작업명으로 해주세요.-->

## 💡 Summary

<!-- 관련 있는 Issue를 태그해주세요. -->

> close #76 

<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해 주세요. -->

## ✅ Tasks

<!-- 해당 PR에서 진행한 작업을 작성해 주세요. -->

- 빌드 시 스토리북 테스트를 비활성화 합니다.

<!-- 기재 내용 없을 경우 해당 섹션을 삭제해 주세요. -->

## 👀 To Reviewer

<!-- 더 전달할 내용 혹은 리뷰어에게 요청하는 내용을 작성해주세요. -->

Vercel 배포오류로 서두를 시작합니다.

로그 중
```
SB_CORE-SERVER_0006 (MainFileMissingError): 
No configuration files have been found in your configDir: /vercel/path0/.storybook
```
-> 스토리북 패키지는 설치되어 있는데, 
.storybook/main.ts 가 없어서 생기는 오류
라고 하기엔 있는데?

-> 배포 환경에서의 경로를 보기
-> 제대로 추적되고 있음

문제는 Vercel의 빌드 프로세스에서 @storybook/addon-vitest 플러그인이 실행되면서 발생하는 것 같아요. 
빌드 시 @storybook/addon-vitest 플러그인이 실행되지 않도록 수정했습니다.

```
storybookTest({
  configDir: path.join(dirname, '.storybook'),
}),
```
그래서 

`const isTest = process.env.NODE_ENV === 'test';`

이 코드 한 줄을 vite.config.ts에 추가했습니다.

vite.config.ts에 isTest 조건을 추가하여 테스트 환경에서만 Storybook 테스트 실행
빌드 환경(NODE_ENV=production)에서는 Storybook 관련 플러그인 비활성화

-> 이렇게 되면 스토리북을 테스트 환경에서만 사용합니다.
Storybook 테스트는 UI 시각적 테스트 용도이므로, 실제 배포 빌드와는 무관하므로 UI 테스트는 로컬 및 CI 테스트 환경에서만 실행되면 충분하다고 판단했습니다.
Vercel 배포 빌드를 방해하지 않도록 storybookTest 플러그인을 배포 환경에서 완전히 비활성화합니다.



....

제발제발제발


<!-- 기재 내용 없을 경우 해당 섹션을 삭제해 주세요. -->

## 📸 Screenshot

<!-- 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요한 경우 .gif 형식으로 첨부해 주세요.-->
