### PR TITLE
[Fix]: 나의 할 일 뷰 이전 날짜 무한 이동 제한 적용

### DIFF
--- a/src/api/domain/edit/index.ts
+++ b/src/api/domain/edit/index.ts
@@ -34,6 +34,7 @@ export interface SubGoal {
 
 export interface SubGoalsResponse {
   subGoals: SubGoal[];
+  isYesterdayExist?: boolean;
 }
 
 // 상위 목표 id, position 조회 API
@@ -61,6 +62,7 @@ export const getSubGoals = async (
   mandalartId: number,
   coreGoalId?: number,
   cycle?: CycleType,
+  date?: string,
 ): Promise<BaseResponse<SubGoalsResponse>> => {
   const queryParams = new URLSearchParams();
   if (coreGoalId !== undefined) {
@@ -68,6 +70,9 @@ export const getSubGoals = async (
   }
   if (cycle) {
     queryParams.append('cycle', cycle);
+  }
+  if (date) {
+    queryParams.append('date', date);
   }
 
   const queryString = queryParams.toString();

--- a/src/api/domain/myTodo/hook/useMyMandal.ts
+++ b/src/api/domain/myTodo/hook/useMyMandal.ts
@@ -35,10 +35,11 @@ export const useGetMandalartSubGoals = (
   mandalartId: number,
   coreGoalId?: number,
   cycle?: string,
+  date?: string,
 ) => {
   return useQuery({
-    queryKey: QUERY_KEY.MANDALART_SUB_GOALS(mandalartId, coreGoalId, cycle),
-    queryFn: () => getSubGoals(mandalartId, coreGoalId, cycle as CycleType),
+    queryKey: [...QUERY_KEY.MANDALART_SUB_GOALS(mandalartId, coreGoalId, cycle), date],
+    queryFn: () => getSubGoals(mandalartId, coreGoalId, cycle as CycleType, date),
     enabled: !!mandalartId,
   });
 };

--- a/src/api/domain/myTodo/type/recommendation.ts
+++ b/src/api/domain/myTodo/type/recommendation.ts
@@ -7,4 +7,5 @@ export type RecommendationSubGoal = {
 
 export type RecommendationResponse = {
   subGoals: RecommendationSubGoal[];
+  isYesterdayExist?: boolean;
 };

--- a/src/common/util/format.ts
+++ b/src/common/util/format.ts
@@ -5,6 +5,10 @@ export function formatDateDot(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+export function toDateOnly(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
 export function createDate(year: number, month: number, day: number): Date {
   return new Date(year, month - 1, day);
 }

--- a/src/page/todo/myTodo/MyTodo.tsx
+++ b/src/page/todo/myTodo/MyTodo.tsx
@@ -34,7 +34,6 @@ const MyTodo = ({
     handleDateChange,
     handleCycleClick,
     handleRecommendTodoClick,
-    handleMyTodoClick,
   } = useMyTodo({
     initialDate: selectedDate,
     initialRecommendTodos,
@@ -68,9 +67,10 @@ const MyTodo = ({
                 title: data?.title || mandalartData?.title || DEFAULT_MANDALART_DATA.title,
               }}
               onCycleClick={handleCycleClick}
-              onTodoClick={handleMyTodoClick}
+              onTodoClick={() => {}}
               onMandalartClick={setSelectedParentId}
               selectedParentId={selectedParentId}
+              currentDate={currentDate}
             />
           </section>
         </div>

--- a/src/page/todo/myTodo/MyTodo.tsx
+++ b/src/page/todo/myTodo/MyTodo.tsx
@@ -67,7 +67,6 @@ const MyTodo = ({
                 title: data?.title || mandalartData?.title || DEFAULT_MANDALART_DATA.title,
               }}
               onCycleClick={handleCycleClick}
-              onTodoClick={() => {}}
               onMandalartClick={setSelectedParentId}
               selectedParentId={selectedParentId}
               currentDate={currentDate}

--- a/src/page/todo/myTodo/component/TodoCheckSection/TodoCheckSection.tsx
+++ b/src/page/todo/myTodo/component/TodoCheckSection/TodoCheckSection.tsx
@@ -14,6 +14,7 @@ import { TodoBox } from '@/page/todo/myTodo/component/TodoBox';
 import type { CycleType } from '@/page/todo/myTodo/component/CycleChip';
 import type { TodoItemTypes } from '@/page/todo/myTodo/component/TodoBox/TodoBox.types';
 import Mandalart from '@/common/component/Mandalart/Mandalart';
+import { formatDateDot } from '@/common/util/format';
 
 interface TodoCheckSectionProps {
   selectedCycle: CycleType | undefined;
@@ -51,7 +52,7 @@ const TodoCheckSection = ({
     mandalartId,
     selectedParentId,
     selectedCycle,
-    currentDate ? currentDate.toISOString().split('T')[0] : undefined,
+    currentDate ? formatDateDot(currentDate) : undefined,
   );
 
   const [localSubGoals, setLocalSubGoals] = useState<TodoItemTypes[]>([]);

--- a/src/page/todo/myTodo/component/TodoCheckSection/TodoCheckSection.tsx
+++ b/src/page/todo/myTodo/component/TodoCheckSection/TodoCheckSection.tsx
@@ -22,6 +22,7 @@ interface TodoCheckSectionProps {
   onTodoClick: (item: TodoItemTypes) => void;
   onMandalartClick: (parentId: number | undefined) => void;
   selectedParentId: number | undefined;
+  currentDate?: Date;
 }
 
 const CYCLE_LIST: CycleType[] = ['DAILY', 'WEEKLY', 'ONCE'];
@@ -38,6 +39,7 @@ const TodoCheckSection = ({
   onTodoClick,
   onMandalartClick,
   selectedParentId,
+  currentDate,
 }: TodoCheckSectionProps) => {
   const mandalartId = useMandalartId();
   const { data: coreGoalsData } = useGetMandalCoreGoals(mandalartId);
@@ -45,7 +47,12 @@ const TodoCheckSection = ({
     data: subGoalResponse,
     isLoading: isSubGoalsLoading,
     isFetching: isSubGoalsFetching,
-  } = useGetMandalartSubGoals(mandalartId, selectedParentId, selectedCycle);
+  } = useGetMandalartSubGoals(
+    mandalartId,
+    selectedParentId,
+    selectedCycle,
+    currentDate ? currentDate.toISOString().split('T')[0] : undefined,
+  );
 
   const [localSubGoals, setLocalSubGoals] = useState<TodoItemTypes[]>([]);
 

--- a/src/page/todo/myTodo/component/TodoCheckSection/TodoCheckSection.tsx
+++ b/src/page/todo/myTodo/component/TodoCheckSection/TodoCheckSection.tsx
@@ -20,7 +20,6 @@ interface TodoCheckSectionProps {
   selectedCycle: CycleType | undefined;
   mandalartData: MandalartData;
   onCycleClick: (cycle: CycleType) => void;
-  onTodoClick: (item: TodoItemTypes) => void;
   onMandalartClick: (parentId: number | undefined) => void;
   selectedParentId: number | undefined;
   currentDate?: Date;
@@ -37,7 +36,6 @@ const TodoCheckSection = ({
   selectedCycle,
   mandalartData,
   onCycleClick,
-  onTodoClick,
   onMandalartClick,
   selectedParentId,
   currentDate,
@@ -87,7 +85,6 @@ const TodoCheckSection = ({
     const nextCompleted = !originalCompleted;
 
     updateLocalSubGoalCompletion(item.id, nextCompleted);
-    onTodoClick({ ...item, isCompleted: nextCompleted });
 
     if (originalCompleted) {
       uncheckSubGoalMutation.mutate(Number(item.id), {

--- a/src/page/todo/myTodo/hook/useMyTodo.ts
+++ b/src/page/todo/myTodo/hook/useMyTodo.ts
@@ -8,22 +8,7 @@ import { useGetRecommendation } from '@/api/domain/myTodo/hook/useGetRecommendat
 import { usePostRecommendation } from '@/api/domain/myTodo/hook/usePostRecommendation';
 import { useDeleteRecommendation } from '@/api/domain/myTodo/hook/useDeleteRecommendation';
 import { useMandalartId } from '@/common/hook/useMandalartId';
-
-const mockSubGoals = Array.from({ length: 8 * 8 }, (_, i) => {
-  const parentId = Math.floor(i / 8) + 1;
-  const order = (i % 8) + 1;
-  const cycles: CycleType[] = ['DAILY', 'WEEKLY', 'ONCE'];
-  const cycle = cycles[i % 3];
-  return {
-    id: parentId * 100 + order,
-    title: `${parentId}-${order} 하위 목표`,
-    content: `${parentId}-${order} 하위 목표`,
-    cycle,
-    parentId,
-    order,
-    isCompleted: false,
-  };
-});
+import { useGetMandalartSubGoals } from '@/api/domain/myTodo/hook/useMyMandal';
 
 interface UseMyTodoProps {
   initialDate?: Date;
@@ -33,17 +18,17 @@ interface UseMyTodoProps {
 
 export const useMyTodo = ({ initialDate }: UseMyTodoProps = {}) => {
   const defaultDate = initialDate ?? new Date();
-  const startOfMonth = new Date(defaultDate.getFullYear(), defaultDate.getMonth(), 1);
-  const endOfMonth = new Date(defaultDate.getFullYear(), defaultDate.getMonth() + 1, 0);
 
   const [currentDate, setCurrentDate] = useState(defaultDate);
   const [selectedCycle, setSelectedCycle] = useState<CycleType>();
   const [selectedParentId, setSelectedParentId] = useState<number>();
-  const [todos, setTodos] = useState<TodoItemTypes[]>([]);
   const [recommendTodos, setRecommendTodos] = useState<TodoItemTypes[]>([]);
 
   const mandalartId = useMandalartId();
   const formattedDate = formatDateDot(currentDate);
+  const isoDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
+    .toISOString()
+    .split('T')[0];
   const { data: recommendationData, refetch } = useGetRecommendation(mandalartId, formattedDate);
   const { mutate: completeTodo } = usePostRecommendation();
   const { mutate: deleteTodo } = useDeleteRecommendation();
@@ -63,21 +48,28 @@ export const useMyTodo = ({ initialDate }: UseMyTodoProps = {}) => {
     }
   }, [recommendationData]);
 
-  useEffect(() => {
-    setTodos(mockSubGoals);
-  }, []);
-
-  const hasPreviousDate = currentDate > startOfMonth;
+  const { data: subGoalsMeta } = useGetMandalartSubGoals(
+    mandalartId,
+    selectedParentId,
+    selectedCycle,
+    isoDate,
+  );
 
   const today = new Date();
-  const isToday = currentDate.toDateString() === today.toDateString();
-  const hasNextDate = currentDate < endOfMonth && !isToday;
+  const todayNoTime = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const currentNoTime = new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth(),
+    currentDate.getDate(),
+  );
+  const hasPreviousDate = Boolean(subGoalsMeta?.data?.isYesterdayExist);
+  const hasNextDate = currentNoTime < todayNoTime;
 
   const handleDateChange = (newDate: Date) => {
     const today = new Date();
     const isFutureDate = newDate.getTime() > today.getTime();
 
-    if (newDate < startOfMonth || newDate > endOfMonth || isFutureDate) {
+    if (isFutureDate) {
       return;
     }
     setCurrentDate(newDate);
@@ -116,35 +108,16 @@ export const useMyTodo = ({ initialDate }: UseMyTodoProps = {}) => {
     }
   };
 
-  const handleMyTodoClick = (item: TodoItemTypes) => {
-    setTodos((prev) =>
-      prev.map((todo) => (todo.id === item.id ? { ...todo, completed: !todo.completed } : todo)),
-    );
-    // TODO: 할 일 완료 상태 API 호출 필요 시 추가
-  };
-
-  const handleMandalartClick = () => {
-    // TODO: 만다라트 클릭 로직
-  };
-
-  const filteredTodos = todos
-    .filter((todo) => !selectedCycle || todo.cycle === selectedCycle)
-    .filter((todo) => !selectedParentId || todo.parentId === selectedParentId)
-    .sort((a, b) => (a.parentId ?? 0) - (b.parentId ?? 0) || (a.order ?? 0) - (b.order ?? 0));
-
   return {
     currentDate,
     selectedCycle,
     selectedParentId,
     setSelectedParentId,
-    todos: filteredTodos,
     recommendTodos,
     hasPreviousDate,
     hasNextDate,
     handleDateChange,
     handleCycleClick,
     handleRecommendTodoClick,
-    handleMyTodoClick,
-    handleMandalartClick,
   };
 };

--- a/src/page/todo/myTodo/hook/useMyTodo.ts
+++ b/src/page/todo/myTodo/hook/useMyTodo.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import type { CycleType } from '../constant/mock';
 
 import type { TodoItemTypes } from '@/page/todo/myTodo/component/TodoBox/TodoBox.types';
-import { formatDateDot } from '@/common/util/format';
+import { formatDateDot, toDateOnly } from '@/common/util/format';
 import { useGetRecommendation } from '@/api/domain/myTodo/hook/useGetRecommendation';
 import { usePostRecommendation } from '@/api/domain/myTodo/hook/usePostRecommendation';
 import { useDeleteRecommendation } from '@/api/domain/myTodo/hook/useDeleteRecommendation';
@@ -26,9 +26,6 @@ export const useMyTodo = ({ initialDate }: UseMyTodoProps = {}) => {
 
   const mandalartId = useMandalartId();
   const formattedDate = formatDateDot(currentDate);
-  const isoDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
-    .toISOString()
-    .split('T')[0];
   const { data: recommendationData, refetch } = useGetRecommendation(mandalartId, formattedDate);
   const { mutate: completeTodo } = usePostRecommendation();
   const { mutate: deleteTodo } = useDeleteRecommendation();
@@ -52,16 +49,12 @@ export const useMyTodo = ({ initialDate }: UseMyTodoProps = {}) => {
     mandalartId,
     selectedParentId,
     selectedCycle,
-    isoDate,
+    formattedDate,
   );
 
   const today = new Date();
-  const todayNoTime = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  const currentNoTime = new Date(
-    currentDate.getFullYear(),
-    currentDate.getMonth(),
-    currentDate.getDate(),
-  );
+  const todayNoTime = toDateOnly(today);
+  const currentNoTime = toDateOnly(currentDate);
   const hasPreviousDate = Boolean(subGoalsMeta?.data?.isYesterdayExist);
   const hasNextDate = currentNoTime < todayNoTime;
 


### PR DESCRIPTION
## 💡 Summary
> close #224 

이전 이동은 응답의 isYesterdayExist로만 허용하고, 오늘 이후로의 이동은 차단했습니다. sub-goals API에 date를 함께 보내고, 날짜 비교는 로컬 자정 기준으로 처리해 시분초 영향을 제거했습니다.

## ✅ Tasks
- sub-goals API에 date 파라미터 추가 및 isYesterdayExist 활용
- 날짜 네비게이션을 isYesterdayExist/오늘 기준으로 적용 (자정 비교)
- TodoCheckSection에 currentDate 전달, 날짜별 queryKey 분리
- 불필요한 목/로컬 상태 및 핸들러 제거
- toDateOnly 유틸 함수 추가 및 formatDateDot으로 날짜 변환 통일

## 👀 To Reviewer
이전 버튼은 isYesterdayExist가 true일 때만, 다음 버튼은 오늘 이전일 때만 활성화되는지 확인 부탁드립니다 !!